### PR TITLE
Fix user signup issue and change dropdown menu to non-bootstrap

### DIFF
--- a/app/controllers/registration/registrations_controller.rb
+++ b/app/controllers/registration/registrations_controller.rb
@@ -61,7 +61,7 @@ class Registration::RegistrationsController < Devise::RegistrationsController
   private
 
   def sign_up_params
-    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :organization_id, :location_id, :email, :password, :password_confirmation)
   end
 
   def account_update_params

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,16 +17,16 @@
 
 
   <div class="field">
-  <div class="dropdown">
-  <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">Organization<br />
-  <span class="caret"></span></button>
-    <%= f.hidden_field :organization_id %>
-    <ul>
-    <% Organization.all do |o| %>
-    <li><%= o.name %></li>
-    <% end %>
-    </ul>
+    <%= f.label :organization %><br />
+    <%= f.collection_select :organization_id, Organization.order(:name),:id,:name %>
+    </br>
   </div>
+
+
+  <div class="field">
+    <%= f.label :location %><br />
+    <%= f.collection_select :location_id, Location.order(:name),:id,:name %>
+    </br>
   </div>
 
   <div class="field">


### PR DESCRIPTION
This changes the parameters permitted to a new user on the backend which fixes the bug we had with Rails blocking a new user from signing up. Also includes tweaks to the frontend of the new user sign-up page to fix the dropdown menus.
